### PR TITLE
Clone from https, build on Mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu
 
 # To initate the build, run
-# docker build -t "pimeet"
+# `docker build -t "pimeet" .`
 # from the command line.
 
 WORKDIR /root/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN  apt-get update \
 ADD ./build /root/build
 ADD ./scripts /root/scripts
 
-CMD   ssh-keygen && \
-      ./download-img.sh && \
-      ./prep-img.sh
+CMD   ssh-keygen \
+  && ./download-img.sh \
+  && ./prep-img.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN  apt-get update \
 
 ADD ./build /root/build
 ADD ./scripts /root/scripts
-ADD ./raspios-img /root/raspios-img/
 
  CMD   ssh-keygen && \
        ./download-img.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN  apt-get update \
 ADD ./build /root/build
 ADD ./scripts /root/scripts
 
- CMD   ssh-keygen && \
-       ./download-img.sh && \
-       ./prep-img.sh
+CMD   ssh-keygen && \
+      ./download-img.sh && \
+      ./prep-img.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu
+
+# To initate the build, run
+# docker build -t "pimeet"
+# from the command line.
+
+WORKDIR /root/build
+  
+RUN  apt-get update \
+  && apt-get install -y wget unzip whois git tree sudo openssh-client \
+  && rm -rf /var/lib/apt/lists/*
+
+ADD ./build /root/build
+ADD ./scripts /root/scripts
+ADD ./raspios-img /root/raspios-img/
+
+ CMD   ssh-keygen && \
+       ./download-img.sh && \
+       ./prep-img.sh

--- a/build/prep-img.sh
+++ b/build/prep-img.sh
@@ -144,7 +144,7 @@ debug 'config.txt' "`cat "$BOOT_CONFIG_FILE" | grep 'gpio-fan'`"
 echo
 echo "Copying programs.."
 GIT_TMP=`mktemp -d`
-git clone -q git@github.com:pmansour/minimeet.git "$GIT_TMP/minimeet/"
+git clone -q https://github.com/pmansour/minimeet.git "$GIT_TMP/minimeet/"
 sudo rm -rf "$DISK_MOUNT_PATH/usr/local/minimeet"
 sudo cp -r "$GIT_TMP/minimeet/mv3/." "$DISK_MOUNT_PATH/usr/local/minimeet/"
 rm -rf GIT_TMP

--- a/build/write-img-mac.sh
+++ b/build/write-img-mac.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Prerequisites: Docker
+# Tested on MacOS 12.2.1
+# Author: behoyh
+
+# NOTE: EXPERIMENTAL. Use at your own risk!
+# Requires Dockerfile to have written .iso image first, eg.
+# docker run -it -v /dev:/dev -v $HOME/raspios-img/output/:/root/raspios-img/ --privileged pimeet
+# where '$HOME/raspios-img/output/' is the location of the image.
+
+IMG_FILE="$HOME/raspios-img/output/2022-01-28-raspios-bullseye-arm64.img"
+DEVICE='/dev/rdisk5'  # Find intended device (not partition) by running `diskutil list`.
+                      # Should look something like '/dev/disk5' for a USB adapter, or '/dev/disk6' for a native SD card slot.
+
+diskutil unmountDisk ${DEVICE}
+
+# press CONTROL + T while executing to see progress
+sudo dd if=${IMG_FILE} of=${DEVICE} bs=1m

--- a/build/write-img-mac.sh
+++ b/build/write-img-mac.sh
@@ -6,7 +6,7 @@
 # NOTE: EXPERIMENTAL. Use at your own risk!
 # Requires Dockerfile to have written .iso image first, eg.
 # docker run -it -v /dev:/dev -v $HOME/raspios-img/output/:/root/raspios-img/ --privileged pimeet
-# where '$HOME/raspios-img/output/' is the location of the image.
+# where '$HOME/raspios-img/output/' is the location of the image on the host.
 
 IMG_FILE="$HOME/raspios-img/output/2022-01-28-raspios-bullseye-arm64.img"
 DEVICE='/dev/rdisk5'  # Find intended device (not partition) by running `diskutil list`.


### PR DESCRIPTION
Small change to prep-img.sh that simplifies rsa key management (in the case it is not already configured with GitHub) 